### PR TITLE
Require Node.js 8 and ESLint 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "ava"

--- a/package.json
+++ b/package.json
@@ -52,15 +52,14 @@
 		"simple"
 	],
 	"dependencies": {
-		"eslint-config-xo": "^0.26.0"
+		"eslint-config-xo": "^0.27.2"
 	},
 	"devDependencies": {
-		"ava": "^1.1.0",
-		"eslint": "^5.12.0",
-		"is-plain-obj": "^1.0.0",
-		"temp-write": "^3.1.0"
+		"ava": "^2.4.0",
+		"eslint": "^6.6.0",
+		"is-plain-obj": "^2.0.0"
 	},
 	"peerDependencies": {
-		"eslint": "^5.12.0"
+		"eslint": ">=6.6.0"
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,14 +1,14 @@
 import test from 'ava';
 import isPlainObj from 'is-plain-obj';
 import eslint from 'eslint';
-import tempWrite from 'temp-write';
+import path from 'path';
 
 const fixture = `'use strict';\nconst x = true;\n\nif (x) {\n  console.log();\n}\n`;
 
 function runEslint(str, conf) {
 	const linter = new eslint.CLIEngine({
 		useEslintrc: false,
-		configFile: tempWrite.sync(JSON.stringify(conf))
+		configFile: path.join(__dirname, conf)
 	});
 
 	return linter.executeOnText(str).results[0].messages;
@@ -18,14 +18,14 @@ test('main', t => {
 	const conf = require('../');
 	t.true(isPlainObj(conf));
 	t.true(isPlainObj(conf.rules));
-	t.is(runEslint(fixture, conf).length, 0);
+	t.is(runEslint(fixture, '../index.js').length, 0);
 });
 
 test('browser', t => {
 	const conf = require('../browser');
 	t.true(isPlainObj(conf));
 	t.true(isPlainObj(conf.rules));
-	t.is(runEslint(fixture, conf).length, 0);
+	t.is(runEslint(fixture, '../browser.js').length, 0);
 });
 
 test('esnext', t => {
@@ -33,6 +33,6 @@ test('esnext', t => {
 	t.true(isPlainObj(conf));
 	t.true(isPlainObj(conf.rules));
 
-	const errors = runEslint('class Foo {}\n', conf);
+	const errors = runEslint('class Foo {}\n', '../esnext.js');
 	t.is(errors[0].ruleId, 'no-unused-vars');
 });


### PR DESCRIPTION
updated everything to the latest versions let me know if you would rather i match eslint-config-xo https://github.com/xojs/eslint-config-xo/blob/master/package.json#L55-L62

Currently, this package warns peerdependency when using eslint 6

Adds testing in node 12 and removes 6

BREAKING CHANGE: changes the minimum node version to 8 in package.json